### PR TITLE
updated create_token_mint, create_associated_token_account

### DIFF
--- a/examples/token_operations.rs
+++ b/examples/token_operations.rs
@@ -29,16 +29,16 @@ fn main() -> Result<(), SolanaKiteError> {
     println!("✅ Created user wallet: {}", user.pubkey());
 
     // Create a token mint with 6 decimals (like USDC)
-    let mint = create_token_mint(&mut litesvm, &mint_authority, 6)?;
-    println!("✅ Created token mint: {}", mint.pubkey());
+    let mint = create_token_mint(&mut litesvm, &mint_authority, 6, None)?;
+    println!("✅ Created token mint: {}", mint);
     println!("   Decimals: 6");
     println!("   Mint authority: {}", mint_authority.pubkey());
 
     // Create an associated token account for the user
     let user_token_account = create_associated_token_account(
         &mut litesvm,
-        &user,
-        &mint.pubkey(),
+        &user.pubkey(),
+        &mint,
         &user,
     )?;
     println!("✅ Created associated token account: {}", user_token_account);
@@ -52,7 +52,7 @@ fn main() -> Result<(), SolanaKiteError> {
     let mint_amount = 1_000_000_000; // 1000 tokens with 6 decimals
     mint_tokens_to_account(
         &mut litesvm,
-        &mint.pubkey(),
+        &mint,
         &user_token_account,
         mint_amount,
         &mint_authority,
@@ -72,7 +72,7 @@ fn main() -> Result<(), SolanaKiteError> {
     let additional_mint = 500_000_000; // 500 more tokens
     mint_tokens_to_account(
         &mut litesvm,
-        &mint.pubkey(),
+        &mint,
         &user_token_account,
         additional_mint,
         &mint_authority,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! let mut litesvm = LiteSVM::new();
 //! let wallet = create_wallet(&mut litesvm, 1_000_000_000).unwrap(); // 1 SOL
-//! let mint = create_token_mint(&mut litesvm, &wallet, 6).unwrap(); // 6 decimals
+//! let mint = create_token_mint(&mut litesvm, &wallet, 6, None).unwrap(); // 6 decimals
 //! ```
 
 pub mod error;


### PR DESCRIPTION
Updated create_token_mint and create_associated_token_account, corresponding docs and tests

**Changes Made**
- `create_token_mint` function:
1. Added optional mint parameter: `mint: Option<Pubkey>` - allows users to specify a custom mint address or let the function generate one
2. Changed return type: From `Result<Keypair, SolanaKiteError>` to `Result<Pubkey, SolanaKiteError>` - now returns just the public key instead of the full keypair
3. Used `Pubkey::new_unique()`: Instead of `Keypair::new()` for generating random addresses
- `create_associated_token_account` function:
1. Changed owner parameter: From `&Keypair` to `&Pubkey` - more flexible as you only need the public key, not the full keypair
2. Removed owner from signing: The owner no longer needs to sign the transaction since only the payer needs to sign for ATA creation

**Positive Aspects of Changes**
- Better flexibility: The optional mint parameter allows for deterministic testing and custom mint addresses
- More efficient: Not requiring the owner keypair for ATA creation is correct - only the payer needs to sign
- Cleaner API: Returning Pubkey instead of Keypair for the mint makes sense if the private key isn't needed elsewhere