### PR TITLE
Rename Token-2022 → Token Extensions throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Token-2022 module** (`token_2022`):
-  - `create_token_2022_mint` — create mints with any combination of 8 extension types
-  - `create_token_2022_account` — create ATAs for Token-2022 mints
-  - `mint_tokens_to_account_2022` — mint tokens via Token-2022
-  - `transfer_checked_token_2022` — TransferChecked with extra account support (for hooks)
-  - `get_token_2022_balance` / `assert_token_2022_balance` — balance helpers
+- **Token Extensions module** (`token_extensions`):
+  - `create_token_extensions_mint` — create mints with any combination of 8 extension types
+  - `create_token_extensions_account` — create ATAs for Token Extensions mints
+  - `mint_tokens_to_token_extensions_account` — mint tokens via Token Extensions
+  - `transfer_checked_token_extensions` — TransferChecked with extra account support (for hooks)
+  - `get_token_extensions_balance` / `assert_token_extensions_balance` — balance helpers
   - `MintExtension` enum: TransferHook, TransferFee, MintCloseAuthority, PermanentDelegate, NonTransferable, DefaultAccountState, InterestBearing, MetadataPointer
 - **Transfer hook module** (`transfer_hook`):
   - `ExtraAccountMeta` — describes additional accounts for transfer hooks
@@ -29,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `initialize_extra_account_meta_list` — initialise the PDA for a hook program
   - `build_transfer_hook_extra_accounts` — build extra accounts for transfers
 - **`deploy_program_bytes`** — deploy programs from `&[u8]` (for `include_bytes!` workflows)
-- **Token-2022 example** (`examples/token_2022_operations.rs`)
-- **11 new Token-2022 integration tests** covering all extension types
+- **Token Extensions example** (`examples/token_extensions_operations.rs`)
+- **11 new Token Extensions integration tests** covering all extension types
 
 ## [0.2.1] - 2025-10-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-kite"
-# Breaking change: Solana 3.x / Anchor 1.0 support, Token-2022 module, removed deprecated TestError
+# Breaking change: Solana 3.x / Anchor 1.0 support, Token Extensions module, removed deprecated TestError
 version = "0.3.0"
 edition = "2021"
 authors = ["Mike MacCana <mike.maccana@gmail.com>"]
@@ -51,8 +51,8 @@ name = "token_operations"
 path = "examples/token_operations.rs"
 
 [[example]]
-name = "token_2022_operations"
-path = "examples/token_2022_operations.rs"
+name = "token_extensions_operations"
+path = "examples/token_extensions_operations.rs"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Documentation](https://docs.rs/solana-kite/badge.svg)](https://docs.rs/solana-kite)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 
-A Rust library that works great with [LiteSVM](https://litesvm.org) for testing your Solana programs. High-level abstractions for common Solana operations — wallets, transactions, SPL tokens, Token-2022 extensions, transfer hooks, PDAs, and program deployment.
+A Rust library that works great with [LiteSVM](https://litesvm.org) for testing your Solana programs. High-level abstractions for common Solana operations — wallets, transactions, SPL tokens, Token Extensions, transfer hooks, PDAs, and program deployment.
 
 ## Features
 
 - 🚀 **Program Deployment**: Deploy programs from files or bytes (`include_bytes!`)
 - 💸 **Transaction Utilities**: Send transactions from instructions with proper signing
 - 🪙 **SPL Token Operations**: Create mints, ATAs, mint tokens, check balances
-- 🔐 **Token-2022 Extensions**: Create mints with transfer hooks, transfer fees, permanent delegates, non-transferable tokens, and more
+- 🔐 **Token Extensions**: Create mints with transfer hooks, transfer fees, permanent delegates, non-transferable tokens, and more
 - 🪝 **Transfer Hook Support**: ExtraAccountMetaList setup and transfer helpers
 - 👛 **Wallet Management**: Create funded wallets in one call
 - 🔑 **PDA Utilities**: Type-safe seed handling with the `seeds!` macro
@@ -92,19 +92,19 @@ mint_tokens_to_account(&mut svm, &mint, &ata, 1_000_000_000, &authority)?;
 assert_token_balance(&svm, &ata, 1_000_000_000, "Should have 1B tokens");
 ```
 
-### Token-2022 Extensions
+### Token Extensions
 
 Create mints with extensions — transfer hooks, transfer fees, permanent delegates, non-transferable tokens, and more:
 
 ```rust
 use solana_kite::{
-    create_token_2022_mint, create_token_2022_account,
-    mint_tokens_to_account_2022, transfer_checked_token_2022,
+    create_token_extensions_mint, create_token_extensions_account,
+    mint_tokens_to_token_extensions_account, transfer_checked_token_extensions,
     MintExtension,
 };
 
 // Create a mint with transfer fee extension
-let mint = create_token_2022_mint(
+let mint = create_token_extensions_mint(
     &mut svm,
     &authority,
     6,
@@ -115,10 +115,10 @@ let mint = create_token_2022_mint(
 )?;
 
 // Create token accounts, mint, and transfer
-let sender_ata = create_token_2022_account(&mut svm, &sender.pubkey(), &mint, &payer)?;
-let receiver_ata = create_token_2022_account(&mut svm, &receiver.pubkey(), &mint, &payer)?;
-mint_tokens_to_account_2022(&mut svm, &mint, &sender_ata, 1_000_000, &authority)?;
-transfer_checked_token_2022(&mut svm, &sender_ata, &mint, &receiver_ata, &sender, 500_000, 6, &[])?;
+let sender_ata = create_token_extensions_account(&mut svm, &sender.pubkey(), &mint, &payer)?;
+let receiver_ata = create_token_extensions_account(&mut svm, &receiver.pubkey(), &mint, &payer)?;
+mint_tokens_to_token_extensions_account(&mut svm, &mint, &sender_ata, 1_000_000, &authority)?;
+transfer_checked_token_extensions(&mut svm, &sender_ata, &mint, &receiver_ata, &sender, 500_000, 6, &[])?;
 ```
 
 **Supported extensions:**
@@ -200,7 +200,7 @@ match some_operation() {
 ```bash
 cargo run --example basic_usage
 cargo run --example token_operations
-cargo run --example token_2022_operations
+cargo run --example token_extensions_operations
 ```
 
 ## Testing

--- a/examples/token_extensions_operations.rs
+++ b/examples/token_extensions_operations.rs
@@ -1,13 +1,13 @@
-//! Example: Token-2022 operations with Solana Kite
+//! Example: Token Extensions operations with Solana Kite
 //!
-//! Demonstrates creating Token-2022 mints with extensions, creating token accounts,
+//! Demonstrates creating Token Extensions mints with extensions, creating token accounts,
 //! minting tokens, and transferring between accounts.
 
 use litesvm::LiteSVM;
 use solana_kite::create_wallet;
-use solana_kite::token_2022::{
-    assert_token_2022_balance, create_token_2022_account, create_token_2022_mint,
-    mint_tokens_to_account_2022, transfer_checked_token_2022, MintExtension,
+use solana_kite::token_extensions::{
+    assert_token_extensions_balance, create_token_extensions_account, create_token_extensions_mint,
+    mint_tokens_to_token_extensions_account, transfer_checked_token_extensions, MintExtension,
 };
 use solana_signer::Signer;
 
@@ -18,8 +18,8 @@ fn main() {
     let authority = create_wallet(&mut litesvm, 2_000_000_000).unwrap();
     let user = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
-    // Create a Token-2022 mint with MintCloseAuthority and PermanentDelegate extensions
-    let mint = create_token_2022_mint(
+    // Create a Token Extensions mint with MintCloseAuthority and PermanentDelegate extensions
+    let mint = create_token_extensions_mint(
         &mut litesvm,
         &authority,
         6,
@@ -33,25 +33,25 @@ fn main() {
         ],
     )
     .unwrap();
-    println!("Created Token-2022 mint: {}", mint);
+    println!("Created Token Extensions mint: {}", mint);
 
     // Create associated token accounts
     let authority_ata =
-        create_token_2022_account(&mut litesvm, &authority.pubkey(), &mint, &authority).unwrap();
+        create_token_extensions_account(&mut litesvm, &authority.pubkey(), &mint, &authority).unwrap();
     let user_ata =
-        create_token_2022_account(&mut litesvm, &user.pubkey(), &mint, &user).unwrap();
+        create_token_extensions_account(&mut litesvm, &user.pubkey(), &mint, &user).unwrap();
     println!("Authority ATA: {}", authority_ata);
     println!("User ATA:      {}", user_ata);
 
     // Mint 1,000,000 tokens (with 6 decimals = 1.0 tokens)
     let mint_amount = 1_000_000;
-    mint_tokens_to_account_2022(&mut litesvm, &mint, &authority_ata, mint_amount, &authority)
+    mint_tokens_to_token_extensions_account(&mut litesvm, &mint, &authority_ata, mint_amount, &authority)
         .unwrap();
     println!("Minted {} tokens to authority", mint_amount);
 
     // Transfer 250,000 tokens to user
     let transfer_amount = 250_000;
-    transfer_checked_token_2022(
+    transfer_checked_token_extensions(
         &mut litesvm,
         &authority_ata,
         &mint,
@@ -65,13 +65,13 @@ fn main() {
     println!("Transferred {} tokens to user", transfer_amount);
 
     // Verify final balances
-    assert_token_2022_balance(
+    assert_token_extensions_balance(
         &litesvm,
         &authority_ata,
         750_000,
         "Authority should have 750,000",
     );
-    assert_token_2022_balance(&litesvm, &user_ata, 250_000, "User should have 250,000");
+    assert_token_extensions_balance(&litesvm, &user_ata, 250_000, "User should have 250,000");
 
-    println!("All Token-2022 operations completed successfully!");
+    println!("All Token Extensions operations completed successfully!");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! - **Program Deployment**: Deploy programs to a test environment (from files or bytes)
 //! - **Transaction Utilities**: Send transactions from instructions with proper signing
 //! - **Token Operations**: Create mints, associated token accounts, and mint tokens
-//! - **Token-2022 Support**: Create Token-2022 mints with extensions, transfer hooks, and more
+//! - **Token Extensions Support**: Create Token Extensions mints with extensions, transfer hooks, and more
 //! - **Account Management**: Create wallets, check balances, and manage account state
 //! - **PDA Utilities**: Generate Program Derived Addresses with type-safe seed handling
 //!
@@ -28,7 +28,7 @@ pub mod error;
 pub mod pda;
 pub mod program;
 pub mod token;
-pub mod token_2022;
+pub mod token_extensions;
 pub mod transaction;
 pub mod transfer_hook;
 pub mod wallet;

--- a/src/token_extensions.rs
+++ b/src/token_extensions.rs
@@ -1,6 +1,6 @@
-//! Token-2022 (Token Extensions) operations for Solana.
+//! Token Extensions operations for Solana.
 //!
-//! This module provides helpers for creating and interacting with Token-2022 mints
+//! This module provides helpers for creating and interacting with Token Extensions mints
 //! and accounts. All instructions are built from raw bytes to avoid depending on
 //! the `spl-token-2022` crate, which can cause version conflicts with `anchor-lang`.
 //!
@@ -18,7 +18,7 @@
 //! # Example
 //!
 //! ```rust
-//! use solana_kite::token_2022::{create_token_2022_mint, MintExtension};
+//! use solana_kite::token_extensions::{create_token_extensions_mint, MintExtension};
 //! use solana_kite::create_wallet;
 //! use litesvm::LiteSVM;
 //! use solana_pubkey::Pubkey;
@@ -27,7 +27,7 @@
 //! let mut litesvm = LiteSVM::new();
 //! let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 //!
-//! let mint = create_token_2022_mint(
+//! let mint = create_token_extensions_mint(
 //!     &mut litesvm,
 //!     &authority,
 //!     6,
@@ -49,11 +49,11 @@ use solana_transaction::Transaction;
 
 // ─── Program IDs ─────────────────────────────────────────────────────────────
 
-/// The Token-2022 program ID.
-pub const TOKEN_2022_PROGRAM_ID: Pubkey =
+/// The Token Extensions program ID.
+pub const TOKEN_EXTENSIONS_PROGRAM_ID: Pubkey =
     solana_pubkey::pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
-/// The Associated Token Account program ID (shared with Token-2022).
+/// The Associated Token Account program ID (shared with Token Extensions).
 const ASSOCIATED_TOKEN_PROGRAM_ID: Pubkey =
     solana_pubkey::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
@@ -63,7 +63,7 @@ const SYSTEM_PROGRAM_ID: Pubkey =
 
 // ─── Account Layout Constants ────────────────────────────────────────────────
 
-/// Base size for Account (not Mint). The Token-2022 extension framework pads
+/// Base size for Account (not Mint). The Token Extensions extension framework pads
 /// all account types (including Mints) to this size before appending extensions.
 const BASE_ACCOUNT_LENGTH: usize = 165;
 
@@ -79,10 +79,10 @@ const TLV_HEADER_SIZE: usize = 4;
 
 // ─── Extension Types ─────────────────────────────────────────────────────────
 
-/// Extensions that can be applied to a Token-2022 mint at creation time.
+/// Extensions that can be applied to a Token Extensions mint at creation time.
 ///
-/// Each variant corresponds to a Token-2022 extension that modifies mint behaviour.
-/// Extensions are initialized *before* the mint itself, following the Token-2022
+/// Each variant corresponds to a Token Extensions extension that modifies mint behaviour.
+/// Extensions are initialized *before* the mint itself, following the Token Extensions
 /// protocol requirement.
 #[derive(Debug, Clone)]
 pub enum MintExtension {
@@ -176,7 +176,7 @@ impl MintExtension {
                 data.extend_from_slice(&mint_authority.to_bytes()); // authority
                 data.extend_from_slice(&program_id.to_bytes());     // program_id
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -201,7 +201,7 @@ impl MintExtension {
                 data.extend_from_slice(&fee_basis_points.to_le_bytes());
                 data.extend_from_slice(&maximum_fee.to_le_bytes());
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -214,7 +214,7 @@ impl MintExtension {
                 data.push(1);  // COption::Some
                 data.extend_from_slice(&close_authority.to_bytes());
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -225,7 +225,7 @@ impl MintExtension {
                 data.push(35); // InitializePermanentDelegate
                 data.extend_from_slice(&delegate.to_bytes());
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -233,7 +233,7 @@ impl MintExtension {
             MintExtension::NonTransferable => {
                 // InitializeNonTransferableMint (instruction 32)
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data: vec![32],
                 }
@@ -241,7 +241,7 @@ impl MintExtension {
             MintExtension::DefaultAccountState { state } => {
                 // DefaultAccountStateExtension (prefix=28) + Initialize (sub=0) + state(1)
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data: vec![28, 0, *state],
                 }
@@ -259,7 +259,7 @@ impl MintExtension {
                 data.extend_from_slice(&rate_authority.to_bytes()); // OptionalNonZeroPubkey
                 data.extend_from_slice(&rate.to_le_bytes());
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -276,7 +276,7 @@ impl MintExtension {
                 data.extend_from_slice(&authority.to_bytes());
                 data.extend_from_slice(&metadata_address.to_bytes());
                 Instruction {
-                    program_id: TOKEN_2022_PROGRAM_ID,
+                    program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
                     accounts: vec![AccountMeta::new(*mint, false)],
                     data,
                 }
@@ -289,7 +289,7 @@ impl MintExtension {
 
 fn calculate_mint_size(extensions: &[MintExtension]) -> usize {
     if extensions.is_empty() {
-        // Without extensions, a Token-2022 mint is the same size as SPL Token
+        // Without extensions, a Token Extensions mint is the same size as SPL Token
         return 82;
     }
     let extension_data_size: usize = extensions.iter().map(|ext| ext.tlv_size()).sum();
@@ -298,10 +298,10 @@ fn calculate_mint_size(extensions: &[MintExtension]) -> usize {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-/// Creates a new Token-2022 mint with the specified extensions.
+/// Creates a new Token Extensions mint with the specified extensions.
 ///
 /// Extensions are initialized before the mint itself, as required by the
-/// Token-2022 program. The `mint_authority` is both the payer and the
+/// Token Extensions program. The `mint_authority` is both the payer and the
 /// mint authority for the new mint.
 ///
 /// # Arguments
@@ -313,12 +313,12 @@ fn calculate_mint_size(extensions: &[MintExtension]) -> usize {
 ///
 /// # Returns
 ///
-/// The public key of the newly created Token-2022 mint.
+/// The public key of the newly created Token Extensions mint.
 ///
 /// # Example
 ///
 /// ```rust
-/// use solana_kite::token_2022::{create_token_2022_mint, MintExtension};
+/// use solana_kite::token_extensions::{create_token_extensions_mint, MintExtension};
 /// use solana_kite::create_wallet;
 /// use litesvm::LiteSVM;
 /// use solana_pubkey::Pubkey;
@@ -328,7 +328,7 @@ fn calculate_mint_size(extensions: &[MintExtension]) -> usize {
 /// let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 /// let hook_program = Pubkey::new_unique();
 ///
-/// let mint = create_token_2022_mint(
+/// let mint = create_token_extensions_mint(
 ///     &mut litesvm,
 ///     &authority,
 ///     6,
@@ -338,7 +338,7 @@ fn calculate_mint_size(extensions: &[MintExtension]) -> usize {
 ///     ],
 /// ).unwrap();
 /// ```
-pub fn create_token_2022_mint(
+pub fn create_token_extensions_mint(
     litesvm: &mut LiteSVM,
     mint_authority: &Keypair,
     decimals: u8,
@@ -348,21 +348,21 @@ pub fn create_token_2022_mint(
     let mint_size = calculate_mint_size(extensions);
     let rent = litesvm.minimum_balance_for_rent_exemption(mint_size);
 
-    // Pre-allocate the account owned by Token-2022
+    // Pre-allocate the account owned by Token Extensions
     litesvm
         .set_account(
             mint,
             solana_account::Account {
                 lamports: rent,
                 data: vec![0u8; mint_size],
-                owner: TOKEN_2022_PROGRAM_ID,
+                owner: TOKEN_EXTENSIONS_PROGRAM_ID,
                 executable: false,
                 rent_epoch: 0,
             },
         )
         .map_err(|e| {
             SolanaKiteError::TokenOperationFailed(format!(
-                "Failed to create Token-2022 mint account: {:?}",
+                "Failed to create Token Extensions mint account: {:?}",
                 e
             ))
         })?;
@@ -382,7 +382,7 @@ pub fn create_token_2022_mint(
     init_mint_data.push(0); // freeze_authority: None
 
     instructions.push(Instruction {
-        program_id: TOKEN_2022_PROGRAM_ID,
+        program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
         accounts: vec![AccountMeta::new(mint, false)],
         data: init_mint_data,
     });
@@ -394,7 +394,7 @@ pub fn create_token_2022_mint(
 
     litesvm.send_transaction(transaction).map_err(|e| {
         SolanaKiteError::TokenOperationFailed(format!(
-            "Failed to initialize Token-2022 mint: {:?}",
+            "Failed to initialize Token Extensions mint: {:?}",
             e
         ))
     })?;
@@ -402,22 +402,22 @@ pub fn create_token_2022_mint(
     Ok(mint)
 }
 
-/// Creates an associated token account for a Token-2022 mint.
+/// Creates an associated token account for a Token Extensions mint.
 ///
 /// Derives the ATA address from the owner and mint, then creates it using
-/// the Associated Token Account program (which supports both Token and Token-2022).
+/// the Associated Token Account program (which supports both Token and Token Extensions).
 ///
 /// # Arguments
 ///
 /// * `litesvm` - Mutable reference to the LiteSVM instance
 /// * `owner` - Public key of the account that will own the token account
-/// * `mint` - Public key of the Token-2022 mint
+/// * `mint` - Public key of the Token Extensions mint
 /// * `payer` - Keypair that pays for account creation
 ///
 /// # Returns
 ///
 /// The public key of the created associated token account.
-pub fn create_token_2022_account(
+pub fn create_token_extensions_account(
     litesvm: &mut LiteSVM,
     owner: &Pubkey,
     mint: &Pubkey,
@@ -435,7 +435,7 @@ pub fn create_token_2022_account(
             AccountMeta::new_readonly(*owner, false),                // wallet address
             AccountMeta::new_readonly(*mint, false),                 // token mint
             AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),     // system program
-            AccountMeta::new_readonly(TOKEN_2022_PROGRAM_ID, false), // token program
+            AccountMeta::new_readonly(TOKEN_EXTENSIONS_PROGRAM_ID, false), // token program
         ],
         data: vec![], // CreateAssociatedTokenAccount has no data
     };
@@ -447,7 +447,7 @@ pub fn create_token_2022_account(
 
     litesvm.send_transaction(transaction).map_err(|e| {
         SolanaKiteError::TokenOperationFailed(format!(
-            "Failed to create Token-2022 associated token account: {:?}",
+            "Failed to create Token Extensions associated token account: {:?}",
             e
         ))
     })?;
@@ -455,16 +455,16 @@ pub fn create_token_2022_account(
     Ok(associated_token_account)
 }
 
-/// Mints tokens to a Token-2022 token account.
+/// Mints tokens to a Token Extensions token account.
 ///
 /// # Arguments
 ///
 /// * `litesvm` - Mutable reference to the LiteSVM instance
-/// * `mint` - Public key of the Token-2022 mint
+/// * `mint` - Public key of the Token Extensions mint
 /// * `token_account` - Public key of the destination token account
 /// * `amount` - Number of tokens to mint (in base units)
 /// * `mint_authority` - Keypair with mint authority
-pub fn mint_tokens_to_account_2022(
+pub fn mint_tokens_to_token_extensions_account(
     litesvm: &mut LiteSVM,
     mint: &Pubkey,
     token_account: &Pubkey,
@@ -476,7 +476,7 @@ pub fn mint_tokens_to_account_2022(
     data.extend_from_slice(&amount.to_le_bytes());
 
     let instruction = Instruction {
-        program_id: TOKEN_2022_PROGRAM_ID,
+        program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
         accounts: vec![
             AccountMeta::new(*mint, false),
             AccountMeta::new(*token_account, false),
@@ -492,7 +492,7 @@ pub fn mint_tokens_to_account_2022(
 
     litesvm.send_transaction(transaction).map_err(|e| {
         SolanaKiteError::TokenOperationFailed(format!(
-            "Failed to mint Token-2022 tokens: {:?}",
+            "Failed to mint Token Extensions tokens: {:?}",
             e
         ))
     })?;
@@ -500,9 +500,9 @@ pub fn mint_tokens_to_account_2022(
     Ok(())
 }
 
-/// Transfers tokens between Token-2022 accounts using TransferChecked.
+/// Transfers tokens between Token Extensions accounts using TransferChecked.
 ///
-/// TransferChecked is required for Token-2022 tokens (especially those with
+/// TransferChecked is required for Token Extensions tokens (especially those with
 /// transfer hooks, transfer fees, or other extensions that need to inspect
 /// the transfer).
 ///
@@ -516,7 +516,7 @@ pub fn mint_tokens_to_account_2022(
 /// * `amount` - Amount to transfer (in base units)
 /// * `decimals` - Mint decimals (must match the mint's configured decimals)
 /// * `extra_accounts` - Additional account metas required by transfer hooks
-pub fn transfer_checked_token_2022(
+pub fn transfer_checked_token_extensions(
     litesvm: &mut LiteSVM,
     source: &Pubkey,
     mint: &Pubkey,
@@ -540,7 +540,7 @@ pub fn transfer_checked_token_2022(
     accounts.extend_from_slice(extra_accounts);
 
     let instruction = Instruction {
-        program_id: TOKEN_2022_PROGRAM_ID,
+        program_id: TOKEN_EXTENSIONS_PROGRAM_ID,
         accounts,
         data,
     };
@@ -552,7 +552,7 @@ pub fn transfer_checked_token_2022(
 
     litesvm.send_transaction(transaction).map_err(|e| {
         SolanaKiteError::TokenOperationFailed(format!(
-            "Failed to transfer Token-2022 tokens: {:?}",
+            "Failed to transfer Token Extensions tokens: {:?}",
             e
         ))
     })?;
@@ -562,15 +562,15 @@ pub fn transfer_checked_token_2022(
 
 // ─── Utility Functions ───────────────────────────────────────────────────────
 
-/// Derives the associated token address for a Token-2022 mint.
+/// Derives the associated token address for a Token Extensions mint.
 ///
 /// Uses the same derivation as the standard ATA program, but with the
-/// Token-2022 program ID.
+/// Token Extensions program ID.
 pub fn get_associated_token_address_2022(owner: &Pubkey, mint: &Pubkey) -> Pubkey {
     let (address, _bump) = Pubkey::find_program_address(
         &[
             owner.as_ref(),
-            TOKEN_2022_PROGRAM_ID.as_ref(),
+            TOKEN_EXTENSIONS_PROGRAM_ID.as_ref(),
             mint.as_ref(),
         ],
         &ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -578,22 +578,22 @@ pub fn get_associated_token_address_2022(owner: &Pubkey, mint: &Pubkey) -> Pubke
     address
 }
 
-/// Gets the token balance of a Token-2022 token account.
+/// Gets the token balance of a Token Extensions token account.
 ///
 /// The account layout is the same as SPL Token for the base fields:
 /// amount is at bytes 64..72 (u64, little-endian).
-pub fn get_token_2022_balance(
+pub fn get_token_extensions_balance(
     litesvm: &LiteSVM,
     token_account: &Pubkey,
 ) -> Result<u64, SolanaKiteError> {
     let account = litesvm.get_account(token_account).ok_or_else(|| {
-        SolanaKiteError::TokenOperationFailed("Token-2022 account not found".to_string())
+        SolanaKiteError::TokenOperationFailed("Token Extensions account not found".to_string())
     })?;
 
     let data = &account.data;
     if data.len() < 72 {
         return Err(SolanaKiteError::TokenOperationFailed(
-            "Invalid Token-2022 account data length".to_string(),
+            "Invalid Token Extensions account data length".to_string(),
         ));
     }
 
@@ -601,7 +601,7 @@ pub fn get_token_2022_balance(
     let amount = u64::from_le_bytes(
         data[64..72].try_into().map_err(|_| {
             SolanaKiteError::TokenOperationFailed(
-                "Failed to parse Token-2022 token amount".to_string(),
+                "Failed to parse Token Extensions token amount".to_string(),
             )
         })?,
     );
@@ -609,16 +609,16 @@ pub fn get_token_2022_balance(
     Ok(amount)
 }
 
-/// Asserts that a Token-2022 token account has the expected balance.
+/// Asserts that a Token Extensions token account has the expected balance.
 ///
-/// Convenience wrapper around [`get_token_2022_balance`] for test assertions.
-pub fn assert_token_2022_balance(
+/// Convenience wrapper around [`get_token_extensions_balance`] for test assertions.
+pub fn assert_token_extensions_balance(
     litesvm: &LiteSVM,
     token_account: &Pubkey,
     expected_balance: u64,
     message: &str,
 ) {
     let actual_balance =
-        get_token_2022_balance(litesvm, token_account).expect("Failed to get Token-2022 balance");
+        get_token_extensions_balance(litesvm, token_account).expect("Failed to get Token Extensions balance");
     assert_eq!(actual_balance, expected_balance, "{}", message);
 }

--- a/src/transfer_hook.rs
+++ b/src/transfer_hook.rs
@@ -1,14 +1,14 @@
-//! Transfer hook helpers for Token-2022.
+//! Transfer hook helpers for Token Extensions.
 //!
-//! When a Token-2022 mint has the TransferHook extension, every transfer
+//! When a Token Extensions mint has the TransferHook extension, every transfer
 //! invokes a program-defined hook. That hook program must store an
-//! `ExtraAccountMetaList` account that tells the Token-2022 runtime which
+//! `ExtraAccountMetaList` account that tells the Token Extensions runtime which
 //! additional accounts to pass into the hook.
 //!
 //! This module provides a helper to initialise that account.
 
 use crate::error::SolanaKiteError;
-use crate::token_2022::TOKEN_2022_PROGRAM_ID;
+use crate::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID;
 use litesvm::LiteSVM;
 use solana_instruction::account_meta::AccountMeta;
 use solana_instruction::Instruction;
@@ -22,7 +22,7 @@ use solana_transaction::Transaction;
 
 /// Describes an additional account that the transfer hook program requires.
 ///
-/// The Token-2022 runtime reads these from the `ExtraAccountMetaList` PDA
+/// The Token Extensions runtime reads these from the `ExtraAccountMetaList` PDA
 /// and appends them to the CPI into the hook program.
 #[derive(Debug, Clone)]
 pub struct ExtraAccountMeta {
@@ -72,7 +72,7 @@ pub fn get_extra_account_metas_address(mint: &Pubkey, hook_program_id: &Pubkey) 
 ///
 /// * `litesvm` - Mutable reference to the LiteSVM instance
 /// * `hook_program_id` - The transfer hook program ID
-/// * `mint` - The Token-2022 mint with the TransferHook extension
+/// * `mint` - The Token Extensions mint with the TransferHook extension
 /// * `authority` - The mint authority / payer keypair
 /// * `extra_metas` - Slice of extra account metas the hook needs
 ///
@@ -133,10 +133,10 @@ pub fn initialize_extra_account_meta_list(
     Ok(())
 }
 
-/// Builds the extra accounts needed for a Token-2022 transfer with a transfer hook.
+/// Builds the extra accounts needed for a Token Extensions transfer with a transfer hook.
 ///
 /// Returns the account metas that should be passed as `extra_accounts` to
-/// [`crate::token_2022::transfer_checked_token_2022`]. This includes the
+/// [`crate::token_extensions::transfer_checked_token_extensions`]. This includes the
 /// ExtraAccountMetaList PDA, the hook program, and any user-defined extra accounts.
 pub fn build_transfer_hook_extra_accounts(
     mint: &Pubkey,
@@ -162,8 +162,8 @@ pub fn build_transfer_hook_extra_accounts(
         extra_account_metas_address,
         false,
     ));
-    // Token-2022 also passes the Token-2022 program itself as the last account
-    accounts.push(AccountMeta::new_readonly(TOKEN_2022_PROGRAM_ID, false));
+    // Token Extensions also passes the Token Extensions program itself as the last account
+    accounts.push(AccountMeta::new_readonly(TOKEN_EXTENSIONS_PROGRAM_ID, false));
 
     accounts
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -164,14 +164,14 @@ fn test_multiple_token_mints() {
     );
 }
 
-// ─── Token-2022 Tests ────────────────────────────────────────────────────────
+// ─── Token Extensions Tests ────────────────────────────────────────────────────────
 
-mod token_2022_tests {
+mod token_extensions_tests {
     use litesvm::LiteSVM;
     use solana_kite::create_wallet;
-    use solana_kite::token_2022::{
-        assert_token_2022_balance, create_token_2022_account, create_token_2022_mint,
-        get_token_2022_balance, mint_tokens_to_account_2022, transfer_checked_token_2022,
+    use solana_kite::token_extensions::{
+        assert_token_extensions_balance, create_token_extensions_account, create_token_extensions_mint,
+        get_token_extensions_balance, mint_tokens_to_token_extensions_account, transfer_checked_token_extensions,
         MintExtension,
     };
     use solana_signer::Signer;
@@ -181,7 +181,7 @@ mod token_2022_tests {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -191,11 +191,11 @@ mod token_2022_tests {
         )
         .unwrap();
 
-        // Verify the mint account exists and is owned by Token-2022
+        // Verify the mint account exists and is owned by Token Extensions
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -204,7 +204,7 @@ mod token_2022_tests {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             9,
@@ -217,7 +217,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -226,7 +226,7 @@ mod token_2022_tests {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             0,
@@ -237,7 +237,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -246,7 +246,7 @@ mod token_2022_tests {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -264,18 +264,18 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
     #[test]
-    fn test_token_2022_mint_and_transfer() {
+    fn test_token_extensions_mint_and_transfer() {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 2_000_000_000).unwrap();
         let user = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
         // Create mint with close authority extension
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -287,14 +287,14 @@ mod token_2022_tests {
 
         // Create token accounts
         let authority_ata =
-            create_token_2022_account(&mut litesvm, &authority.pubkey(), &mint, &authority)
+            create_token_extensions_account(&mut litesvm, &authority.pubkey(), &mint, &authority)
                 .unwrap();
         let user_ata =
-            create_token_2022_account(&mut litesvm, &user.pubkey(), &mint, &user).unwrap();
+            create_token_extensions_account(&mut litesvm, &user.pubkey(), &mint, &user).unwrap();
 
         // Mint tokens to authority's account
         let mint_amount = 1_000_000; // 1 token (6 decimals)
-        mint_tokens_to_account_2022(
+        mint_tokens_to_token_extensions_account(
             &mut litesvm,
             &mint,
             &authority_ata,
@@ -303,7 +303,7 @@ mod token_2022_tests {
         )
         .unwrap();
 
-        assert_token_2022_balance(
+        assert_token_extensions_balance(
             &litesvm,
             &authority_ata,
             mint_amount,
@@ -312,7 +312,7 @@ mod token_2022_tests {
 
         // Transfer half to user
         let transfer_amount = 500_000;
-        transfer_checked_token_2022(
+        transfer_checked_token_extensions(
             &mut litesvm,
             &authority_ata,
             &mint,
@@ -324,13 +324,13 @@ mod token_2022_tests {
         )
         .unwrap();
 
-        assert_token_2022_balance(
+        assert_token_extensions_balance(
             &litesvm,
             &authority_ata,
             mint_amount - transfer_amount,
             "Authority balance after transfer",
         );
-        assert_token_2022_balance(
+        assert_token_extensions_balance(
             &litesvm,
             &user_ata,
             transfer_amount,
@@ -339,25 +339,25 @@ mod token_2022_tests {
     }
 
     #[test]
-    fn test_token_2022_balance_helpers() {
+    fn test_token_extensions_balance_helpers() {
         let mut litesvm = LiteSVM::new();
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
         let mint =
-            create_token_2022_mint(&mut litesvm, &authority, 6, &[MintExtension::NonTransferable])
+            create_token_extensions_mint(&mut litesvm, &authority, 6, &[MintExtension::NonTransferable])
                 .unwrap();
 
         let ata =
-            create_token_2022_account(&mut litesvm, &authority.pubkey(), &mint, &authority)
+            create_token_extensions_account(&mut litesvm, &authority.pubkey(), &mint, &authority)
                 .unwrap();
 
         // Initial balance should be zero
-        let balance = get_token_2022_balance(&litesvm, &ata).unwrap();
+        let balance = get_token_extensions_balance(&litesvm, &ata).unwrap();
         assert_eq!(balance, 0);
 
         // Mint and check
-        mint_tokens_to_account_2022(&mut litesvm, &mint, &ata, 42_000, &authority).unwrap();
-        assert_token_2022_balance(&litesvm, &ata, 42_000, "Should have 42000 tokens");
+        mint_tokens_to_token_extensions_account(&mut litesvm, &mint, &ata, 42_000, &authority).unwrap();
+        assert_token_extensions_balance(&litesvm, &ata, 42_000, "Should have 42000 tokens");
     }
 
     #[test]
@@ -366,7 +366,7 @@ mod token_2022_tests {
         let authority = create_wallet(&mut litesvm, 2_000_000_000).unwrap();
 
         // 1% fee, max 1000 base units
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -380,7 +380,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -390,7 +390,7 @@ mod token_2022_tests {
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
         let metadata_address = solana_pubkey::Pubkey::new_unique();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -404,7 +404,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -414,7 +414,7 @@ mod token_2022_tests {
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
 
         // 5% interest rate (500 basis points)
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -428,7 +428,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -439,8 +439,8 @@ mod token_2022_tests {
 
         // Default state: Initialized (1)
         // Note: Frozen (2) requires a freeze authority on the mint,
-        // which create_token_2022_mint doesn't set by default.
-        let mint = create_token_2022_mint(
+        // which create_token_extensions_mint doesn't set by default.
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -451,7 +451,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 
@@ -461,7 +461,7 @@ mod token_2022_tests {
         let authority = create_wallet(&mut litesvm, 1_000_000_000).unwrap();
         let hook_program = solana_pubkey::Pubkey::new_unique();
 
-        let mint = create_token_2022_mint(
+        let mint = create_token_extensions_mint(
             &mut litesvm,
             &authority,
             6,
@@ -474,7 +474,7 @@ mod token_2022_tests {
         let account = litesvm.get_account(&mint).unwrap();
         assert_eq!(
             account.owner,
-            solana_kite::token_2022::TOKEN_2022_PROGRAM_ID
+            solana_kite::token_extensions::TOKEN_EXTENSIONS_PROGRAM_ID
         );
     }
 }


### PR DESCRIPTION
The program is officially called the "Token Extensions Program", not "Token-2022". This renames the module, all public functions, constants, docs, and examples to use consistent naming.

Changes:
- `src/token_2022.rs` → `src/token_extensions.rs`
- All public functions: `*_2022_*` → `*_extensions_*`
- `TOKEN_2022_PROGRAM_ID` → `TOKEN_EXTENSIONS_PROGRAM_ID`
- All docs, comments, README, CHANGELOG updated
- Tests renamed and passing

The `spl-token-2022` crate name is kept where it refers to the upstream package.